### PR TITLE
Fix github language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
So I noticed that Github was somewhat inaccurately classifying this whole package as primarily written in "Jupyter notebook" (rather than Julia) just because of the few example `.ipynb` notebooks in /tutorial. It turns out there is an easy fix for this, just in case this is something you'd like fixed (feel free to close the PR if not!)